### PR TITLE
:sparkles: 엔티티 추가 및 h2 설정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     // ⭐ Spring boot 3.x이상에서 QueryDsl 패키지를 정의하는 방법
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0"
 }
 
 tasks.named('test') {

--- a/src/main/java/ogjg/instagram/comment/domain/InnerComment.java
+++ b/src/main/java/ogjg/instagram/comment/domain/InnerComment.java
@@ -1,10 +1,9 @@
-package ogjg.instagram.story.domain;
+package ogjg.instagram.comment.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.like.domain.StoryLike;
-import ogjg.instagram.user.domain.StoryUserRead;
+import ogjg.instagram.like.domain.InnerCommentLike;
 import ogjg.instagram.user.domain.User;
 
 import java.time.LocalDateTime;
@@ -18,24 +17,23 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Story {
+public class InnerComment {
 
     @Id
-    @Column(name = "story_id")
+    @Column(name = "inner_comment_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = LAZY)
+    private Comment comment;
+
+    @ManyToOne(fetch = LAZY)
     private User user;
 
-    @OneToMany(mappedBy = "story")
-    private List<StoryLike> storyLikes = new ArrayList<>();
+    @OneToMany(mappedBy = "innerComment")
+    private List<InnerCommentLike> innerCommentLikes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "story")
-    private List<StoryUserRead> storyUserReads = new ArrayList<>();
-
-    @OneToMany(mappedBy = "story")
-    private List<StoryMedia> storyMedia = new ArrayList<>();
+    private String content;
 
     private LocalDateTime createdAt;
 }

--- a/src/main/java/ogjg/instagram/feed/domain/Feed.java
+++ b/src/main/java/ogjg/instagram/feed/domain/Feed.java
@@ -1,4 +1,54 @@
 package ogjg.instagram.feed.domain;
 
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ogjg.instagram.comment.domain.Comment;
+import ogjg.instagram.hashtag.domain.Hashtag;
+import ogjg.instagram.like.domain.FeedLike;
+import ogjg.instagram.user.domain.CollectionFeed;
+import ogjg.instagram.user.domain.User;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
 public class Feed {
+
+    @Id
+    @Column(name = "feed_id")
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @OneToMany(mappedBy = "feed")
+    private List<FeedLike> feedLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "feed")
+    private List<CollectionFeed> collectionFeeds = new ArrayList<>();
+
+    @OneToMany(mappedBy = "feed")
+    private List<Hashtag> hashtags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "feed")
+    private List<FeedMedia> feedMedias = new ArrayList<>();
+
+    @OneToMany(mappedBy = "feed")
+    private List<Comment> comments = new ArrayList<>();
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/ogjg/instagram/feed/domain/FeedMedia.java
+++ b/src/main/java/ogjg/instagram/feed/domain/FeedMedia.java
@@ -1,9 +1,8 @@
-package ogjg.instagram.hashtag.domain;
+package ogjg.instagram.feed.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.feed.domain.Feed;
 
 import java.time.LocalDateTime;
 
@@ -14,15 +13,19 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Hashtag {
+public class FeedMedia {
 
     @Id
-    @Column(name = "hashtag_id")
+    @Column(name = "media_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = LAZY)
     private Feed feed;
+
+    private String mediaType;
+
+    private String mediaUrl;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/ogjg/instagram/follow/domain/Follow.java
+++ b/src/main/java/ogjg/instagram/follow/domain/Follow.java
@@ -1,4 +1,26 @@
 package ogjg.instagram.follow.domain;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ogjg.instagram.user.domain.User;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
 public class Follow {
+
+    @EmbeddedId
+    private FollowPK followPK;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @MapsId("followId")
+    @ManyToOne(fetch = LAZY)
+    private User followUser;
 }

--- a/src/main/java/ogjg/instagram/follow/domain/FollowPK.java
+++ b/src/main/java/ogjg/instagram/follow/domain/FollowPK.java
@@ -1,0 +1,11 @@
+package ogjg.instagram.follow.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class FollowPK implements Serializable {
+    private Long userId;
+    private Long followId;
+}

--- a/src/main/java/ogjg/instagram/like/controller/LikesController.java
+++ b/src/main/java/ogjg/instagram/like/controller/LikesController.java
@@ -1,0 +1,4 @@
+package ogjg.instagram.like.controller;
+
+public class LikesController {
+}

--- a/src/main/java/ogjg/instagram/like/domain/CommentLike.java
+++ b/src/main/java/ogjg/instagram/like/domain/CommentLike.java
@@ -1,9 +1,10 @@
-package ogjg.instagram.hashtag.domain;
+package ogjg.instagram.like.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.feed.domain.Feed;
+import ogjg.instagram.comment.domain.Comment;
+import ogjg.instagram.user.domain.User;
 
 import java.time.LocalDateTime;
 
@@ -14,17 +15,22 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Hashtag {
+public class CommentLike {
 
-    @Id
-    @Column(name = "hashtag_id")
+    @Column(name = "comment_like_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
+    @EmbeddedId
+    private CommentLikePK commentLikePK;
+
+    @MapsId("userId")
     @ManyToOne(fetch = LAZY)
-    private Feed feed;
+    private User user;
+
+    @MapsId("commentId")
+    @ManyToOne(fetch = LAZY)
+    private Comment comment;
 
     private LocalDateTime createdAt;
-
-    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/ogjg/instagram/like/domain/CommentLikePK.java
+++ b/src/main/java/ogjg/instagram/like/domain/CommentLikePK.java
@@ -1,0 +1,11 @@
+package ogjg.instagram.like.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class CommentLikePK implements Serializable {
+    private Long userId;
+    private Long commentId;
+}

--- a/src/main/java/ogjg/instagram/like/domain/FeedLike.java
+++ b/src/main/java/ogjg/instagram/like/domain/FeedLike.java
@@ -1,9 +1,10 @@
-package ogjg.instagram.hashtag.domain;
+package ogjg.instagram.like.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ogjg.instagram.feed.domain.Feed;
+import ogjg.instagram.user.domain.User;
 
 import java.time.LocalDateTime;
 
@@ -14,17 +15,22 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Hashtag {
+public class FeedLike {
 
-    @Id
-    @Column(name = "hashtag_id")
+    @Column(name = "feed_like_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
+    @EmbeddedId
+    private FeedLikePK feedLikePK;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @MapsId("feedId")
     @ManyToOne(fetch = LAZY)
     private Feed feed;
 
     private LocalDateTime createdAt;
-
-    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/ogjg/instagram/like/domain/FeedLikePK.java
+++ b/src/main/java/ogjg/instagram/like/domain/FeedLikePK.java
@@ -1,0 +1,11 @@
+package ogjg.instagram.like.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class FeedLikePK implements Serializable {
+    private Long userId;
+    private Long feedId;
+}

--- a/src/main/java/ogjg/instagram/like/domain/InnerCommentLike.java
+++ b/src/main/java/ogjg/instagram/like/domain/InnerCommentLike.java
@@ -1,15 +1,12 @@
-package ogjg.instagram.comment.domain;
+package ogjg.instagram.like.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.feed.domain.Feed;
-import ogjg.instagram.like.domain.CommentLike;
+import ogjg.instagram.comment.domain.InnerComment;
 import ogjg.instagram.user.domain.User;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -18,26 +15,22 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Comment {
+public class InnerCommentLike {
 
-    @Id
-    @Column(name = "comment_id")
+    @Column(name = "inner_comment_like_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = LAZY)
-    private Feed feed;
+    @EmbeddedId
+    private InnerCommentLikePK innerCommentLikePK;
 
+    @MapsId("userId")
     @ManyToOne(fetch = LAZY)
     private User user;
 
-    @OneToMany
-    private List<CommentLike> commentLikes = new ArrayList<>();
-
-    @OneToMany
-    private List<InnerComment> innerComments = new ArrayList<>();
-
-    private String content;
+    @MapsId("innerCommentId")
+    @ManyToOne(fetch = LAZY)
+    private InnerComment innerComment;
 
     private LocalDateTime createdAt;
 }

--- a/src/main/java/ogjg/instagram/like/domain/InnerCommentLikePK.java
+++ b/src/main/java/ogjg/instagram/like/domain/InnerCommentLikePK.java
@@ -1,0 +1,11 @@
+package ogjg.instagram.like.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class InnerCommentLikePK implements Serializable {
+    private Long userId;
+    private Long innerCommentId;
+}

--- a/src/main/java/ogjg/instagram/like/domain/StoryLike.java
+++ b/src/main/java/ogjg/instagram/like/domain/StoryLike.java
@@ -1,9 +1,10 @@
-package ogjg.instagram.hashtag.domain;
+package ogjg.instagram.like.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.feed.domain.Feed;
+import ogjg.instagram.story.domain.Story;
+import ogjg.instagram.user.domain.User;
 
 import java.time.LocalDateTime;
 
@@ -14,17 +15,22 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Hashtag {
+public class StoryLike {
 
-    @Id
-    @Column(name = "hashtag_id")
+    @Column(name = "story_like_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
+    @EmbeddedId
+    private StoryLikePK storyLikePK;
+
+    @MapsId("userId")
     @ManyToOne(fetch = LAZY)
-    private Feed feed;
+    private User user;
+
+    @MapsId("storyId")
+    @ManyToOne(fetch = LAZY)
+    private Story story;
 
     private LocalDateTime createdAt;
-
-    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/ogjg/instagram/like/domain/StoryLikePK.java
+++ b/src/main/java/ogjg/instagram/like/domain/StoryLikePK.java
@@ -1,0 +1,11 @@
+package ogjg.instagram.like.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class StoryLikePK implements Serializable {
+    private Long userId;
+    private Long storyId;
+}

--- a/src/main/java/ogjg/instagram/like/repository/LikesRepository.java
+++ b/src/main/java/ogjg/instagram/like/repository/LikesRepository.java
@@ -1,0 +1,4 @@
+package ogjg.instagram.like.repository;
+
+public class LikesRepository {
+}

--- a/src/main/java/ogjg/instagram/like/service/LikesService.java
+++ b/src/main/java/ogjg/instagram/like/service/LikesService.java
@@ -1,0 +1,4 @@
+package ogjg.instagram.like.service;
+
+public class LikesService {
+}

--- a/src/main/java/ogjg/instagram/likes/controller/LikesController.java
+++ b/src/main/java/ogjg/instagram/likes/controller/LikesController.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.likes.controller;
-
-public class LikesController {
-}

--- a/src/main/java/ogjg/instagram/likes/domain/Likes.java
+++ b/src/main/java/ogjg/instagram/likes/domain/Likes.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.likes.domain;
-
-public class Likes {
-}

--- a/src/main/java/ogjg/instagram/likes/repository/LikesRepository.java
+++ b/src/main/java/ogjg/instagram/likes/repository/LikesRepository.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.likes.repository;
-
-public class LikesRepository {
-}

--- a/src/main/java/ogjg/instagram/likes/service/LikesService.java
+++ b/src/main/java/ogjg/instagram/likes/service/LikesService.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.likes.service;
-
-public class LikesService {
-}

--- a/src/main/java/ogjg/instagram/media/controller/MediaController.java
+++ b/src/main/java/ogjg/instagram/media/controller/MediaController.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.media.controller;
-
-public class MediaController {
-}

--- a/src/main/java/ogjg/instagram/media/domain/Media.java
+++ b/src/main/java/ogjg/instagram/media/domain/Media.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.media.domain;
-
-public class Media {
-}

--- a/src/main/java/ogjg/instagram/media/repository/MediaRepository.java
+++ b/src/main/java/ogjg/instagram/media/repository/MediaRepository.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.media.repository;
-
-public class MediaRepository {
-}

--- a/src/main/java/ogjg/instagram/media/service/MediaService.java
+++ b/src/main/java/ogjg/instagram/media/service/MediaService.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.media.service;
-
-public class MediaService {
-}

--- a/src/main/java/ogjg/instagram/profile/domain/Profile.java
+++ b/src/main/java/ogjg/instagram/profile/domain/Profile.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.profile.domain;
-
-public class Profile {
-}

--- a/src/main/java/ogjg/instagram/story/domain/StoryMedia.java
+++ b/src/main/java/ogjg/instagram/story/domain/StoryMedia.java
@@ -1,9 +1,8 @@
-package ogjg.instagram.hashtag.domain;
+package ogjg.instagram.story.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.feed.domain.Feed;
 
 import java.time.LocalDateTime;
 
@@ -14,17 +13,21 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Hashtag {
+public class StoryMedia {
 
     @Id
-    @Column(name = "hashtag_id")
+    @Column(name = "media_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = LAZY)
-    private Feed feed;
+    private Story story;
+
+    private String mediaType;
+
+    private String mediaUrl;
 
     private LocalDateTime createdAt;
-
-    private LocalDateTime modifiedAt;
 }
+
+

--- a/src/main/java/ogjg/instagram/user/controller/UsersController.java
+++ b/src/main/java/ogjg/instagram/user/controller/UsersController.java
@@ -1,0 +1,4 @@
+package ogjg.instagram.user.controller;
+
+public class UsersController {
+}

--- a/src/main/java/ogjg/instagram/user/domain/Collection.java
+++ b/src/main/java/ogjg/instagram/user/domain/Collection.java
@@ -1,11 +1,8 @@
-package ogjg.instagram.story.domain;
+package ogjg.instagram.user.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.like.domain.StoryLike;
-import ogjg.instagram.user.domain.StoryUserRead;
-import ogjg.instagram.user.domain.User;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -18,24 +15,20 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Entity
 @NoArgsConstructor(access = PROTECTED)
-public class Story {
+public class Collection {
 
     @Id
-    @Column(name = "story_id")
+    @Column(name = "collection_id")
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = LAZY)
     private User user;
 
-    @OneToMany(mappedBy = "story")
-    private List<StoryLike> storyLikes = new ArrayList<>();
+    @OneToMany(mappedBy = "collection")
+    private List<CollectionFeed> collectionFeeds = new ArrayList<>();
 
-    @OneToMany(mappedBy = "story")
-    private List<StoryUserRead> storyUserReads = new ArrayList<>();
-
-    @OneToMany(mappedBy = "story")
-    private List<StoryMedia> storyMedia = new ArrayList<>();
+    private String collectionName;
 
     private LocalDateTime createdAt;
 }

--- a/src/main/java/ogjg/instagram/user/domain/CollectionFeed.java
+++ b/src/main/java/ogjg/instagram/user/domain/CollectionFeed.java
@@ -1,0 +1,33 @@
+package ogjg.instagram.user.domain;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ogjg.instagram.feed.domain.Feed;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class CollectionFeed {
+
+    @EmbeddedId
+    private CollectionFeedPK collectionFeedPK;
+
+    @MapsId("feedId")
+    @ManyToOne(fetch = LAZY)
+    private Feed feed;
+
+    @MapsId("collectionId")
+    @ManyToOne(fetch = LAZY)
+    private Collection collection;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+}

--- a/src/main/java/ogjg/instagram/user/domain/CollectionFeedPK.java
+++ b/src/main/java/ogjg/instagram/user/domain/CollectionFeedPK.java
@@ -1,0 +1,12 @@
+package ogjg.instagram.user.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class CollectionFeedPK implements Serializable {
+    private Long feedId;
+    private Long collectionId;
+    private Long userId;
+}

--- a/src/main/java/ogjg/instagram/user/domain/StoryUserRead.java
+++ b/src/main/java/ogjg/instagram/user/domain/StoryUserRead.java
@@ -1,0 +1,30 @@
+package ogjg.instagram.user.domain;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ogjg.instagram.story.domain.Story;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class StoryUserRead {
+
+    @EmbeddedId
+    private StoryUserReadPK storyUserReadPK;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @MapsId("storyId")
+    @ManyToOne(fetch = LAZY)
+    private Story story;
+
+}

--- a/src/main/java/ogjg/instagram/user/domain/StoryUserReadPK.java
+++ b/src/main/java/ogjg/instagram/user/domain/StoryUserReadPK.java
@@ -1,0 +1,11 @@
+package ogjg.instagram.user.domain;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+
+@Embeddable
+public class StoryUserReadPK implements Serializable {
+    private Long userId;
+    private Long storyId;
+}

--- a/src/main/java/ogjg/instagram/user/domain/User.java
+++ b/src/main/java/ogjg/instagram/user/domain/User.java
@@ -1,0 +1,88 @@
+package ogjg.instagram.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ogjg.instagram.comment.domain.Comment;
+import ogjg.instagram.comment.domain.InnerComment;
+import ogjg.instagram.feed.domain.Feed;
+import ogjg.instagram.follow.domain.Follow;
+import ogjg.instagram.like.domain.CommentLike;
+import ogjg.instagram.like.domain.FeedLike;
+import ogjg.instagram.like.domain.InnerCommentLike;
+import ogjg.instagram.like.domain.StoryLike;
+import ogjg.instagram.story.domain.Story;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "users")
+public class User {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String nickname;
+
+    private String userName;
+
+    private String email;
+
+    private String password;
+
+    private String userIntro;
+
+    private String userImg;
+
+    private boolean recommend;
+
+    private boolean secret;
+
+    private boolean isActive;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    @OneToMany(mappedBy = "user")
+    private List<FeedLike> feedLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Feed> feeds = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Collection> collections = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<CommentLike> commentLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<InnerComment> innerComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<InnerCommentLike> innerCommentLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Story> stories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<StoryLike> storyLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<StoryUserRead> storyUserReads = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Follow> follows = new ArrayList<>();
+}

--- a/src/main/java/ogjg/instagram/user/repository/UsersRepository.java
+++ b/src/main/java/ogjg/instagram/user/repository/UsersRepository.java
@@ -1,0 +1,4 @@
+package ogjg.instagram.user.repository;
+
+public class UsersRepository {
+}

--- a/src/main/java/ogjg/instagram/user/service/UsersService.java
+++ b/src/main/java/ogjg/instagram/user/service/UsersService.java
@@ -1,0 +1,4 @@
+package ogjg.instagram.user.service;
+
+public class UsersService {
+}

--- a/src/main/java/ogjg/instagram/users/controller/UsersController.java
+++ b/src/main/java/ogjg/instagram/users/controller/UsersController.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.users.controller;
-
-public class UsersController {
-}

--- a/src/main/java/ogjg/instagram/users/domain/Users.java
+++ b/src/main/java/ogjg/instagram/users/domain/Users.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.users.domain;
-
-public class Users {
-}

--- a/src/main/java/ogjg/instagram/users/repository/UsersRepository.java
+++ b/src/main/java/ogjg/instagram/users/repository/UsersRepository.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.users.repository;
-
-public class UsersRepository {
-}

--- a/src/main/java/ogjg/instagram/users/service/UsersService.java
+++ b/src/main/java/ogjg/instagram/users/service/UsersService.java
@@ -1,4 +1,0 @@
-package ogjg.instagram.users.service;
-
-public class UsersService {
-}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,1 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/instagram
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
 
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console


### PR DESCRIPTION
### 기능 추가
- 엔티티 추가
- h2 연결 설정 (appliction.yaml)

### 버그 픽스
-  QueryDsl 의존성 마지막 부분에 `:jakarta` 제거. 
    - `:jakarta`는 존재하지 않는 classifier 이다.

close #5