### PR TITLE
✨ 스프링 시큐리티 기본 설정 및 CORS 설정

### DIFF
--- a/src/main/java/ogjg/instagram/config/SecurityConfig.java
+++ b/src/main/java/ogjg/instagram/config/SecurityConfig.java
@@ -8,6 +8,12 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @EnableWebSecurity
 @Configuration
@@ -20,7 +26,10 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(CorsUtils::isPreFlightRequest)
+                        .permitAll()
                         .requestMatchers(HttpMethod.GET, allowedGetPath)
                         .permitAll()
                         .requestMatchers(HttpMethod.POST, allowedPostPath)
@@ -31,5 +40,20 @@ public class SecurityConfig {
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.setAllowCredentials(true);
+        configuration.addExposedHeader("Authorization");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("**", configuration);
+
+        return source;
     }
 }

--- a/src/main/java/ogjg/instagram/config/SecurityConfig.java
+++ b/src/main/java/ogjg/instagram/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package ogjg.instagram.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    private final String[] allowedGetPath = {"/api/users/logout"};
+    private final String[] allowedPostPath = {"/api/users/login", "/api/users/signup"};
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.GET, allowedGetPath)
+                        .permitAll()
+                        .requestMatchers(HttpMethod.POST, allowedPostPath)
+                        .permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 스프링 시큐리티 기본 설정
- Spring Security 6 버전 API를 사용한 설정

```java
private final String[] allowedGetPath = {"/api/users/logout"};
private final String[] allowedPostPath = {"/api/users/login", "/api/users/signup"};
```
- 허가된 URL에만 인증없이 접근이 가능하도록 설정했습니다.
- JWT가 구현되지 않은 관계로 구현이 필요하시다면 임의로 추가 또는 변경해서 사용하시면 됩니다.
```java
.sessionManagement(sessionManagement ->
                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
```
- 세션을 사용하지 않으므로 미사용 옵션을 추가

## CORS 설정
```java
UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
source.registerCorsConfiguration("**", configuration);
```
- 모든 경로에 CORS를 적용
```java
configuration.addAllowedHeader("*");
configuration.addAllowedMethod("*");
configuration.addAllowedOrigin("http://localhost:3000");
```
- Header, Method는 모두 허용
```java
configuration.setAllowCredentials(true);
configuration.addExposedHeader("Authorization");
```
- Refresh Token에 HttpOnly 옵션을 적용할 것이기 때문에 자격 증명(쿠키)을 포함시킬 수 있게 허용
- JWT를 사용하기 때문에 클라이언트에서 Authorization 헤더의 접근을 허용하도록 설정

close #16 