### PR TITLE
:hammer: JWT 재발급 Bugfix

### DIFF
--- a/src/main/java/ogjg/instagram/config/security/jwt/JwtUtils.java
+++ b/src/main/java/ogjg/instagram/config/security/jwt/JwtUtils.java
@@ -41,7 +41,7 @@ public class JwtUtils {
     public static String generateRefreshToken(JwtUserClaimsDto userClaimsDto) {
         return Jwts.builder()
                 .setHeader(createHeader())
-                .setClaims(new HashMap<>(Map.of("iss", ISSUER, "sub", userClaimsDto.getUsername())))
+                .setClaims(createClaims(userClaimsDto))
                 .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_VALID_TIME))
                 .signWith(generateKey())
                 .compact();

--- a/src/main/java/ogjg/instagram/config/security/login/LoginAuthSuccessHandler.java
+++ b/src/main/java/ogjg/instagram/config/security/login/LoginAuthSuccessHandler.java
@@ -74,6 +74,7 @@ public class LoginAuthSuccessHandler {
         }
         if (userAuth.isEmpty()) {
             UserAuthentication savedUserAuth = UserAuthentication.builder()
+                    .userId(userDetails.getUser().getId())
                     .username(userDetails.getUsername())
                     .nickname(userDetails.getNickname())
                     .refreshToken(refreshToken)

--- a/src/main/java/ogjg/instagram/user/domain/UserAuthentication.java
+++ b/src/main/java/ogjg/instagram/user/domain/UserAuthentication.java
@@ -16,6 +16,8 @@ public class UserAuthentication {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private Long userId;
+
     private String username;
 
     private String nickname;
@@ -24,8 +26,9 @@ public class UserAuthentication {
     private String refreshToken;
 
     @Builder
-    public UserAuthentication(Long id, String username, String nickname, String refreshToken) {
+    public UserAuthentication(Long id, Long userId, String username, String nickname, String refreshToken) {
         this.id = id;
+        this.userId = userId;
         this.username = username;
         this.nickname = nickname;
         this.refreshToken = refreshToken;

--- a/src/main/java/ogjg/instagram/user/service/UserService.java
+++ b/src/main/java/ogjg/instagram/user/service/UserService.java
@@ -86,6 +86,7 @@ public class UserService {
 
     private static String getAccessToken(UserAuthentication userAuth) {
         JwtUserClaimsDto userClaimsDto = JwtUserClaimsDto.builder()
+                .userId(userAuth.getId())
                 .username(userAuth.getUsername())
                 .nickname(userAuth.getNickname())
                 .build();
@@ -94,7 +95,7 @@ public class UserService {
 
     private UserAuthentication getUserAuthentication(String refreshToken) {
         Claims claims = getClaims(refreshToken);
-        String username = (String) claims.get("sub");
+        String username = (String) claims.get("email");
 
         return authenticationRepository.findByUsername(username).orElseThrow(
                 () -> new JwtException("Refresh Token을 찾을 수 없습니다."));


### PR DESCRIPTION
### 문제
- Refresh Token 내부 정보에 User에 대한 id 값이 없어 Access Token을 생성할 수 없어 발생

### 해결
- Refresh Token 내부에도 User id 값을 추가

### 고민
- DB 접근 없이 User에 대한 정보를 가진 Access Token을 생성하는 더 좋은 방법이 있을까?

close #47