### PR TITLE
:sparkles: 피드 보관함 삭제/대댓글 작성/프로필 보기 기능에 대한 예외처리 추가

### DIFF
--- a/src/main/java/ogjg/instagram/comment/service/CommentService.java
+++ b/src/main/java/ogjg/instagram/comment/service/CommentService.java
@@ -26,6 +26,7 @@ public class CommentService {
 
     @Transactional
     public List<InnerComment> findInnerComments(Long commentId) {
+        commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("답글을 달기 위한 댓글이 존재하지 않습니다. id = " + commentId));
         return innerCommentRepository.findAllById(commentId);
     }
 

--- a/src/main/java/ogjg/instagram/feed/controller/CollectionController.java
+++ b/src/main/java/ogjg/instagram/feed/controller/CollectionController.java
@@ -44,7 +44,7 @@ public class CollectionController {
         Long loginId = userDetails.getUserId();
         log.info("loginId = {}", loginId);
 
-        collectionService.deleteFeed(feedId, FIXED_COLLECTION_ID, loginId); // todo : collectionId 상수처리
+        collectionService.deleteFeed(feedId, FIXED_COLLECTION_ID, loginId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/ogjg/instagram/feed/repository/CollectionFeedRepository.java
+++ b/src/main/java/ogjg/instagram/feed/repository/CollectionFeedRepository.java
@@ -28,5 +28,13 @@ public interface CollectionFeedRepository extends JpaRepository<CollectionFeed, 
         and cf.collection.id = :collectionId
     """)
     void deleteBy(@Param("feedId") Long feedId, @Param("collectionId") Long collectionId, @Param("userId") Long userId);
+
+    @Query("""
+        select cf from CollectionFeed cf
+        where cf.feed.id = :feedId
+        and cf.user.id = :userId
+        and cf.collection.id = :collectionId
+    """)
+    Optional<CollectionFeed> findById(@Param("feedId") Long feedId, @Param("collectionId") Long collectionId, @Param("userId") Long userId);
 }
 

--- a/src/main/java/ogjg/instagram/feed/service/CollectionService.java
+++ b/src/main/java/ogjg/instagram/feed/service/CollectionService.java
@@ -29,9 +29,11 @@ public class CollectionService {
     }
 
     @Transactional
-    public void deleteFeed(Long feedId, Long collectionID,Long userId) {
-        // todo : 존재하지 않는 Collection 검증 로직
-        collectionFeedRepository.deleteBy(feedId, collectionID,userId);
+    public void deleteFeed(Long feedId, Long collectionId,Long userId) {
+        collectionFeedRepository.findById(feedId, collectionId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 컬렉션입니다. id=" + collectionId));
+
+        collectionFeedRepository.deleteBy(feedId, collectionId,userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ogjg/instagram/feed/service/FeedService.java
+++ b/src/main/java/ogjg/instagram/feed/service/FeedService.java
@@ -50,6 +50,7 @@ public class FeedService {
 
     @Transactional(readOnly = true)
     public ProfileFeedResponseDto findProfileFeedsByUserId(Long userId, Pageable pageable) {
+        userService.findById(userId);
         return ProfileFeedResponseDto.from(profileRepository.findMyFeedsByUserId(userId, pageable));
     }
 
@@ -92,8 +93,9 @@ public class FeedService {
 
     @Transactional
     public void delete(Long userId, Long feedId) {
-        if (notMyFeed(userId, feedId)) throw new IllegalArgumentException("본인의 게시글만 삭제할 수 있습니다.");  // todo : 다른사람 글 삭제 불가 : 에러핸들링
+        if (notMyFeed(userId, feedId)) throw new IllegalArgumentException("본인의 게시글만 삭제할 수 있습니다.");
 
+        // todo : cascade는 쿼리문이 여러개 나간다.
         Feed feed = findById(feedId);
         feed.clearAll();
 //        feedRepository.deleteById(feedId);


### PR DESCRIPTION
- [x] 피드 보관함에서 삭제시 예외처리 추가
- 컬렉션피드맵 테이블에서 삭제 전에 해당 값이 존재하는지 검색
- 컬렉션 테이블을 사용하지 않고 기본 컬렉션을 사용하는 형태
- [x] 대댓글 작성시 해당 댓글 존재 여부 예외 처리
- [x] 프로필 접근 시 유저 아이디 존재 여부 예외 처리

close #60 