### PR TITLE
innerComment 불러오기 기능 누락된 기능 추가

### DIFF
--- a/src/main/java/ogjg/instagram/comment/controller/CommentController.java
+++ b/src/main/java/ogjg/instagram/comment/controller/CommentController.java
@@ -2,8 +2,8 @@ package ogjg.instagram.comment.controller;
 
 import lombok.RequiredArgsConstructor;
 import ogjg.instagram.comment.dto.request.CommentCreateRequestDto;
-import ogjg.instagram.comment.dto.response.InnerCommentListResponseDto;
 import ogjg.instagram.comment.service.CommentService;
+import ogjg.instagram.comment.service.InnerCommentService;
 import ogjg.instagram.config.security.jwt.JwtUserDetails;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -16,19 +16,20 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
 
     private final CommentService commentService;
+    private final InnerCommentService innerCommentService;
 
     /**
      * 피드 대댓글 보기 - 전부 내려주기
      */
     @GetMapping("/comments/{commentId}/inner-comments")
     public ResponseEntity<?> innerCommentList(
-            @PathVariable ("commentId") Long commentId
+            @PathVariable ("commentId") Long commentId,
+            @AuthenticationPrincipal JwtUserDetails userDetails
     ) {
+        Long loginId = userDetails.getUserId();
         return ResponseEntity.ok(
-                InnerCommentListResponseDto.from(
-                        commentId,
-                        commentService.findInnerComments(commentId)
-                ));
+                innerCommentService.innerCommentList(commentId, loginId)
+        );
     }
 
     /**

--- a/src/main/java/ogjg/instagram/comment/controller/InnerCommentController.java
+++ b/src/main/java/ogjg/instagram/comment/controller/InnerCommentController.java
@@ -27,7 +27,6 @@ public class InnerCommentController {
     ) {
         Long loginId = userDetails.getUserId();
 
-
         innerCommentService.write(loginId, commentId, requestDto);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/ogjg/instagram/comment/dto/response/InnerCommentListResponseDto.java
+++ b/src/main/java/ogjg/instagram/comment/dto/response/InnerCommentListResponseDto.java
@@ -5,27 +5,19 @@ import lombok.Getter;
 import ogjg.instagram.comment.domain.InnerComment;
 import ogjg.instagram.user.domain.User;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class InnerCommentListResponseDto {
     private Long commentId;
     private List<InnerCommentListDto> innerComments;
 
+
     @Builder
     public InnerCommentListResponseDto(Long commentId, List<InnerCommentListDto> innerComments) {
         this.commentId = commentId;
         this.innerComments = innerComments;
-    }
-
-    public static InnerCommentListResponseDto from(Long commentId, List<InnerComment> innerComments) {
-        return InnerCommentListResponseDto.builder()
-                .commentId(commentId)
-                .innerComments(innerComments.stream()
-                        .map((innerComment -> InnerCommentListDto.from(innerComment)))
-                        .collect(Collectors.toUnmodifiableList()))
-                .build();
     }
 
     @Getter
@@ -34,19 +26,28 @@ public class InnerCommentListResponseDto {
         private Long innerCommentId;
         private InnerCommentWriter innerCommentWriter;
         private String content;
+        private boolean likeStatus;
+        private Long likeCount;
+        private LocalDateTime createdAt;
 
         @Builder
-        public InnerCommentListDto(User user, Long innerCommentId, String content) {
+        public InnerCommentListDto(User user, Long innerCommentId, String content, boolean likeStatus, Long likeCount, LocalDateTime createdAt) {
             this.innerCommentWriter = new InnerCommentWriter(user);
             this.innerCommentId = innerCommentId;
             this.content = content;
+            this.likeStatus = likeStatus;
+            this.likeCount = likeCount;
+            this.createdAt = createdAt;
         }
 
-        public static InnerCommentListDto from(InnerComment innerComment) {
+        public static InnerCommentListDto from(InnerComment innerComment, boolean likeStatus, Long likeCount) {
             return InnerCommentListDto.builder()
                     .innerCommentId(innerComment.getId())
                     .user(innerComment.getUser())
                     .content(innerComment.getContent())
+                    .likeStatus(likeStatus)
+                    .likeCount(likeCount)
+                    .createdAt(innerComment.getCreatedAt())
                     .build();
         }
 

--- a/src/main/java/ogjg/instagram/comment/service/InnerCommentService.java
+++ b/src/main/java/ogjg/instagram/comment/service/InnerCommentService.java
@@ -4,13 +4,17 @@ import lombok.RequiredArgsConstructor;
 import ogjg.instagram.comment.domain.Comment;
 import ogjg.instagram.comment.domain.InnerComment;
 import ogjg.instagram.comment.dto.request.InnerCommentCreateRequestDto;
+import ogjg.instagram.comment.dto.response.InnerCommentListResponseDto;
 import ogjg.instagram.comment.repository.InnerCommentRepository;
+import ogjg.instagram.like.service.InnerCommentLikeService;
 import ogjg.instagram.user.domain.User;
 import ogjg.instagram.user.service.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -18,6 +22,7 @@ public class InnerCommentService {
     private final UserService userService;
     private final CommentService commentService;
     private final InnerCommentRepository innerCommentRepository;
+    private final InnerCommentLikeService innerCommentLikeService;
 
     @Transactional
     public void write(Long userId, Long commentId, InnerCommentCreateRequestDto requestDto) {
@@ -52,5 +57,26 @@ public class InnerCommentService {
     public InnerComment findById(Long innerCommentId) {
         return innerCommentRepository.findById(innerCommentId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 답글입니다. id =" + innerCommentId));
+    }
+
+    @Transactional(readOnly = true)
+    public InnerCommentListResponseDto innerCommentList(Long commentId, Long userId) {
+        return InnerCommentListResponseDto.builder()
+                .commentId(commentId)
+                .innerComments(
+                        commentService.findInnerComments(commentId).stream()
+                                .map(toInnerCommentListDto(userId))
+                                .collect(Collectors.toUnmodifiableList())
+                )
+                .build();
+    }
+
+    private Function<InnerComment, InnerCommentListResponseDto.InnerCommentListDto> toInnerCommentListDto(Long userId) {
+        return innerComment ->
+                InnerCommentListResponseDto.InnerCommentListDto.from(
+                        innerComment,
+                        innerCommentLikeService.likeStatus(userId, innerComment.getId()),
+                        innerCommentLikeService.innerCommentLikeCount(innerComment.getId())
+                );
     }
 }

--- a/src/main/java/ogjg/instagram/like/controller/InnerCommentLikeController.java
+++ b/src/main/java/ogjg/instagram/like/controller/InnerCommentLikeController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/innerComment")
+@RequestMapping("/api/inner-comment")
 public class InnerCommentLikeController {
 
     private final InnerCommentLikeService innerCommentLikeService;

--- a/src/main/java/ogjg/instagram/like/repository/InnerCommentLikeRepository.java
+++ b/src/main/java/ogjg/instagram/like/repository/InnerCommentLikeRepository.java
@@ -1,12 +1,15 @@
 package ogjg.instagram.like.repository;
 
+import ogjg.instagram.like.domain.feedLike.FeedLike;
 import ogjg.instagram.like.domain.innerCommentLike.InnerCommentLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface InnerCommentLikeRepository extends JpaRepository<InnerCommentLike,Long> {
+import java.util.Optional;
+
+public interface InnerCommentLikeRepository extends JpaRepository<InnerCommentLike, Long> {
 
     @Modifying
     @Query("delete from InnerCommentLike icl where icl.innerCommentLikePK.innerCommentId =:innerCommentId and icl.innerCommentLikePK.userId= :userId")
@@ -14,5 +17,8 @@ public interface InnerCommentLikeRepository extends JpaRepository<InnerCommentLi
     @Query("select count(*) from InnerCommentLike icl where icl.innerCommentLikePK.innerCommentId = :innerCommentId")
     Long countLikes(@Param("innerCommentId") Long innerCommentId);
 
-
+    @Query("""
+            select icl from InnerCommentLike icl where icl.innerComment.id = :innerCommentId and icl.user.id = :userId  
+    """)
+    Optional<InnerCommentLike> likeStatus(@Param("userId") Long userId, @Param("innerCommentId") Long innerCommentId);
 }

--- a/src/main/java/ogjg/instagram/like/service/InnerCommentLikeService.java
+++ b/src/main/java/ogjg/instagram/like/service/InnerCommentLikeService.java
@@ -32,6 +32,7 @@ public class InnerCommentLikeService {
         innerCommentLikeRepository.deleteInnerCommentLike(innerCommentId, userId);
     }
 
+    @Transactional(readOnly = true)
     public Long innerCommentLikeCount(Long innerCommentId){
         return innerCommentLikeRepository.countLikes(innerCommentId);
     }
@@ -46,7 +47,13 @@ public class InnerCommentLikeService {
                 .orElseThrow(() -> new IllegalArgumentException(innerCommentId + ": 대댓글를 찾을 수 없습니다"));
     }
 
+    @Transactional(readOnly = true)
     public Long countInnerComment(Long commentId) {
         return innerCommentRepository.countByCommentId(commentId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean likeStatus(Long userId, Long innerCommentId) {
+        return innerCommentLikeRepository.likeStatus(userId, innerCommentId).isPresent();
     }
 }


### PR DESCRIPTION
- [x] : innerCommentLike 누락된 기능 추가
- 좋아요 눌렀는지 여부 판별하는 기능 추가
- [x] :  innerComment 목록보기 기능 누락된 부분 추가
- 대댓글 좋아요 여부, 대댓글 좋아요 개수, 생성시기 추가
- 좋아요 여부 판별을 위해 토큰에서 logInId 받아오기
- [x] : 카멜 케이스 url 케밥 케이스로 수정
- innerCommnet -> inner-comment


close #82 