### PR TITLE
:rocket: plain.jar 생성하지 않도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,3 +48,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
### 문제
- 빌드 시 plain.jar도 함께 생성되어 Dockerfile이 제대로 작성되지 못하는 문제

### 해결
- plain.jar가 생성되지 않도록 build.gradle에 해당 코드를 추가
