### PR TITLE
:sparkles: 이메일, 닉네임 중복 검사 기능, 로그아웃 기능 구현

### DIFF
--- a/src/main/java/ogjg/instagram/config/security/SecurityConfig.java
+++ b/src/main/java/ogjg/instagram/config/security/SecurityConfig.java
@@ -43,7 +43,9 @@ public class SecurityConfig {
 
     private final List<String> permitJwtUrlList = new ArrayList<>(
             List.of("/api/users/signup",
-                       "/api/users/token"
+                    "/api/users/token",
+                    "/api/users/email/*",
+                    "/api/users/nickname/*"
             ));
 
     @Bean

--- a/src/main/java/ogjg/instagram/config/security/SecurityConfig.java
+++ b/src/main/java/ogjg/instagram/config/security/SecurityConfig.java
@@ -44,8 +44,8 @@ public class SecurityConfig {
     private final List<String> permitJwtUrlList = new ArrayList<>(
             List.of("/api/users/signup",
                     "/api/users/token",
-                    "/api/users/email/*",
-                    "/api/users/nickname/*"
+                    "/api/users/email/.*",
+                    "/api/users/nickname/.*"
             ));
 
     @Bean

--- a/src/main/java/ogjg/instagram/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/ogjg/instagram/config/security/jwt/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -25,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        if (permitUrlList.contains(request.getRequestURI())) {
+        if (isPermitted(request.getRequestURI())) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -45,6 +46,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isPermitted(String requestUri) {
+        for (String pattern : permitUrlList) {
+            if (Pattern.matches(pattern, requestUri)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String getJwt(HttpServletRequest request) {

--- a/src/main/java/ogjg/instagram/user/controller/UserController.java
+++ b/src/main/java/ogjg/instagram/user/controller/UserController.java
@@ -34,19 +34,17 @@ public class UserController {
     @GetMapping("/email/{email}")
     public ResponseEntity<?> checkEmail(@PathVariable @Email String email) {
         if (userService.isEmailAlreadyInUse(email)) {
-            return new ResponseEntity<>("이미 사용되고 있는 이메일입니다.", HttpStatus.BAD_REQUEST);
-        } else {
-            return new ResponseEntity<>("사용 가능한 이메일입니다.", HttpStatus.OK);
+            throw new IllegalArgumentException("이미 사용되고 있는 이메일입니다.");
         }
+        return new ResponseEntity<>("사용 가능한 이메일입니다.", HttpStatus.OK);
     }
 
     @GetMapping("/nickname/{nickname}")
     public ResponseEntity<?> checkNickname(@PathVariable String nickname) {
         if (userService.isNicknameAlreadyInUse(nickname)) {
-            return new ResponseEntity<>("이미 사용되고 있는 닉네임입니다.", HttpStatus.BAD_REQUEST);
-        } else {
-            return new ResponseEntity<>("사용 가능한 닉네임입니다.", HttpStatus.OK);
+            throw new IllegalArgumentException("이미 사용되고 있는 닉네임입니다.");
         }
+        return new ResponseEntity<>("사용 가능한 닉네임입니다.", HttpStatus.OK);
     }
 
     @GetMapping("/logout")

--- a/src/main/java/ogjg/instagram/user/controller/UserController.java
+++ b/src/main/java/ogjg/instagram/user/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
         return new ResponseEntity<>("Access Token 재발급 성공", HttpStatus.OK);
     }
 
-    @GetMapping("/{email}")
+    @GetMapping("/email/{email}")
     public ResponseEntity<?> checkEmail(@PathVariable @Email String email) {
         if (userService.isEmailAlreadyInUse(email)) {
             return new ResponseEntity<>("이미 사용되고 있는 이메일입니다.", HttpStatus.BAD_REQUEST);
@@ -40,7 +40,7 @@ public class UserController {
         }
     }
 
-    @GetMapping("/{nickname}")
+    @GetMapping("/nickname/{nickname}")
     public ResponseEntity<?> checkNickname(@PathVariable String nickname) {
         if (userService.isNicknameAlreadyInUse(nickname)) {
             return new ResponseEntity<>("이미 사용되고 있는 닉네임입니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/ogjg/instagram/user/controller/UserController.java
+++ b/src/main/java/ogjg/instagram/user/controller/UserController.java
@@ -5,10 +5,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
+import ogjg.instagram.config.security.jwt.JwtUserDetails;
 import ogjg.instagram.user.dto.SignupRequestDto;
 import ogjg.instagram.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -47,4 +49,9 @@ public class UserController {
         }
     }
 
+    @GetMapping("/logout")
+    public ResponseEntity<?> logout(@AuthenticationPrincipal JwtUserDetails userDetails) {
+        userService.logout(userDetails.getUsername());
+        return new ResponseEntity<>("로그아웃 되었습니다.", HttpStatus.OK);
+    }
 }

--- a/src/main/java/ogjg/instagram/user/controller/UserController.java
+++ b/src/main/java/ogjg/instagram/user/controller/UserController.java
@@ -3,15 +3,13 @@ package ogjg.instagram.user.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
 import ogjg.instagram.user.dto.SignupRequestDto;
 import ogjg.instagram.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -29,6 +27,15 @@ public class UserController {
     public ResponseEntity<?> generateToken(HttpServletRequest request, HttpServletResponse response) {
         userService.generateToken(request, response);
         return new ResponseEntity<>("Access Token 재발급 성공", HttpStatus.OK);
+    }
+
+    @GetMapping("/{email}")
+    public ResponseEntity<?> checkEmail(@PathVariable @Email String email) {
+        if (userService.isEmailAlreadyInUse(email)) {
+            return new ResponseEntity<>("이미 사용되고 있는 이메일입니다.", HttpStatus.BAD_REQUEST);
+        } else {
+            return new ResponseEntity<>("사용 가능한 이메일입니다.", HttpStatus.OK);
+        }
     }
 
 }

--- a/src/main/java/ogjg/instagram/user/controller/UserController.java
+++ b/src/main/java/ogjg/instagram/user/controller/UserController.java
@@ -38,4 +38,13 @@ public class UserController {
         }
     }
 
+    @GetMapping("/{nickname}")
+    public ResponseEntity<?> checkNickname(@PathVariable String nickname) {
+        if (userService.isNicknameAlreadyInUse(nickname)) {
+            return new ResponseEntity<>("이미 사용되고 있는 닉네임입니다.", HttpStatus.BAD_REQUEST);
+        } else {
+            return new ResponseEntity<>("사용 가능한 닉네임입니다.", HttpStatus.OK);
+        }
+    }
+
 }

--- a/src/main/java/ogjg/instagram/user/service/UserService.java
+++ b/src/main/java/ogjg/instagram/user/service/UserService.java
@@ -84,6 +84,14 @@ public class UserService {
         }
     }
 
+    public boolean isEmailAlreadyInUse(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
+
+    public boolean isNicknameAlreadyInUse(String nickname) {
+        return userRepository.findByNickname(nickname).isPresent();
+    }
+
     private static String getAccessToken(UserAuthentication userAuth) {
         JwtUserClaimsDto userClaimsDto = JwtUserClaimsDto.builder()
                 .userId(userAuth.getUserId())
@@ -109,7 +117,4 @@ public class UserService {
                 .orElseThrow(() -> new RuntimeException("쿠키에 Refresh Token이 존재하지 않습니다."));
     }
 
-    public boolean isEmailAlreadyInUse(String email) {
-        return userRepository.findByEmail(email).isPresent();
-    }
 }

--- a/src/main/java/ogjg/instagram/user/service/UserService.java
+++ b/src/main/java/ogjg/instagram/user/service/UserService.java
@@ -108,4 +108,8 @@ public class UserService {
                 .map(Cookie::getValue)
                 .orElseThrow(() -> new RuntimeException("쿠키에 Refresh Token이 존재하지 않습니다."));
     }
+
+    public boolean isEmailAlreadyInUse(String email) {
+        return userRepository.findByEmail(email).isPresent();
+    }
 }

--- a/src/main/java/ogjg/instagram/user/service/UserService.java
+++ b/src/main/java/ogjg/instagram/user/service/UserService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import static ogjg.instagram.config.security.jwt.JwtUtils.*;
 
@@ -119,4 +120,9 @@ public class UserService {
                 .orElseThrow(() -> new RuntimeException("쿠키에 Refresh Token이 존재하지 않습니다."));
     }
 
+    @Transactional
+    public void logout(String username) {
+        Optional<UserAuthentication> userAuth = authenticationRepository.findByUsername(username);
+        userAuth.ifPresent(authenticationRepository::delete);
+    }
 }

--- a/src/main/java/ogjg/instagram/user/service/UserService.java
+++ b/src/main/java/ogjg/instagram/user/service/UserService.java
@@ -84,10 +84,12 @@ public class UserService {
         }
     }
 
+    @Transactional
     public boolean isEmailAlreadyInUse(String email) {
         return userRepository.findByEmail(email).isPresent();
     }
 
+    @Transactional
     public boolean isNicknameAlreadyInUse(String nickname) {
         return userRepository.findByNickname(nickname).isPresent();
     }


### PR DESCRIPTION
## 구현 기능
- 이메일 중복 검사 기능
- 닉네임 중복 검사 기능
- 로그아웃 기능
    - JWT를 통해 로그인 상태를 구현했기 때문에 사용자에 해당하는 `Refresh Token` 데이터를 삭제하는 방법으로 구현했습니다.

## 발생했던 문제
### URL 경로 매칭 문제
GET 요청을 사용하기 때문에 URL에 검사하는 데이터가 포함되어 전달되는데, 기존의 로직은 정확히 해당 URL의 경로를 비교하기 때문에 필터에서 통과되지 않았습니다.
- 더 정확하게 설명하면, `/*`을 통해 모든 요청에 대해 허용하고 싶었지만 List의 `contains()`를 활용했기 때문에 허용되지 않았습니다.
```java
private final List<String> permitJwtUrlList = new ArrayList<>(
        List.of("/api/users/signup",
                "/api/users/token",
                "/api/users/email/.*",
                "/api/users/nickname/.*"
));
```
```java
private boolean isPermitted(String requestUri) {
    for (String pattern : permitUrlList) {
        if (Pattern.matches(pattern, requestUri)) {
            return true;
        }
    }
    return false;
}
```
- 모든 경로에 대한 허용을 위해 정규표현식을 적용했습니다.
- `/*` 경로를 정규표현식을 사용한 `/.*`로 변경했습니다.
- JWT 인증 필터에 정규표현식을 검증하는 `isPermitted()` 메서드를 구현하여 로직을 변경했습니다.



close #88 
close #89 