### PR TITLE
프로필 응답 식별자 수정, 팔로잉 목록 오류, 게시물 목록 서브쿼리 다중로우 오류 수정

### DIFF
--- a/src/main/java/ogjg/instagram/follow/service/FollowService.java
+++ b/src/main/java/ogjg/instagram/follow/service/FollowService.java
@@ -84,9 +84,9 @@ public class FollowService {
     }
 
     @Transactional(readOnly = true)
-
     public boolean isFollowing(Long loginId, Long userId) {
         return followRepository.followerMeToo(loginId, userId) != null;
+
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ogjg/instagram/profile/dto/response/ProfileFeedResponseDto.java
+++ b/src/main/java/ogjg/instagram/profile/dto/response/ProfileFeedResponseDto.java
@@ -20,8 +20,9 @@ public class ProfileFeedResponseDto {
         this.feedList = feedList;
     }
 
-    public static ProfileFeedResponseDto from(Page<ProfileFeedDto> feedPage) {
+    public static ProfileFeedResponseDto from(Page<Feed> feedPage) {
         List<ProfileFeedDto> feedList = feedPage.getContent().stream()
+                .map((feed -> new ProfileFeedDto(feed)))
         .collect(Collectors.toList());
 
         ProfileFeedResponseDto responseDto = new ProfileFeedResponseDto(feedList);
@@ -72,5 +73,12 @@ public class ProfileFeedResponseDto {
             this.commentCount = Long.valueOf(feed.getComments().size());
         }
 
+        public ProfileFeedDto(Feed feed) {
+            this.feedId = feed.getId();
+            this.mediaUrl = feed.getFeedMedias().get(0).getMediaUrl();
+            this.isMediaOne = feed.getFeedMedias().size() == 1;
+            this.likeCount = Long.valueOf(feed.getFeedLikes().size());
+            this.commentCount = Long.valueOf(feed.getComments().size());
+        }
     }
 }

--- a/src/main/java/ogjg/instagram/profile/dto/response/ProfileResponseDto.java
+++ b/src/main/java/ogjg/instagram/profile/dto/response/ProfileResponseDto.java
@@ -16,7 +16,7 @@ public class ProfileResponseDto {
     private long followingCount;
     private long feedCount;
     private boolean followingStatus;
-    private boolean secretStatus;
+    private boolean isSecret;
 
     public static ProfileResponseDto from(User user, Long feedCount, Long followCount, Long followingCount, boolean followingStatus) {
         return ProfileResponseDto.builder()
@@ -28,7 +28,7 @@ public class ProfileResponseDto {
                 .followingCount(followingCount)
                 .feedCount(feedCount)
                 .followingStatus(followingStatus)
-                .secretStatus(user.isSecret())
+                .isSecret(user.isSecret())
                 .build();
     }
 }

--- a/src/main/java/ogjg/instagram/profile/repository/ProfileRepository.java
+++ b/src/main/java/ogjg/instagram/profile/repository/ProfileRepository.java
@@ -1,6 +1,6 @@
 package ogjg.instagram.profile.repository;
 
-import ogjg.instagram.profile.dto.response.ProfileFeedResponseDto;
+import ogjg.instagram.feed.domain.Feed;
 import ogjg.instagram.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,17 +16,10 @@ public interface ProfileRepository extends JpaRepository<User,Long> {
      * 내 피드 목록 가져오기 - 무한 스크롤 9개씩
      */
     @Query("""
-       SELECT NEW ogjg.instagram.profile.dto.response.ProfileFeedResponseDto$ProfileFeedDto (
-           f.id, 
-           (SELECT fm.mediaUrl FROM FeedMedia fm WHERE fm.feed = f ORDER BY fm.id ASC),
-           (SELECT COUNT(fm) > 1 FROM FeedMedia fm WHERE fm.feed = f),
-           (SELECT COUNT(fl) FROM FeedLike fl WHERE fl.feed = f),
-           (SELECT COUNT(c) FROM Comment c WHERE c.feed = f)
-       )
-       FROM Feed f
-       WHERE f.user.id = :userId
+       SELECT f FROM Feed f WHERE f.user.id = :userId
     """)
-    Page<ProfileFeedResponseDto.ProfileFeedDto> findMyFeedsByUserId(@Param("userId") Long jwt_userId, Pageable pageable);
+    Page<Feed> findMyFeedsByUserId(@Param("userId") Long userId, Pageable pageable);
+
 
     Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/ogjg/instagram/profile/service/ProfileService.java
+++ b/src/main/java/ogjg/instagram/profile/service/ProfileService.java
@@ -42,7 +42,7 @@ public class ProfileService {
                 userService.findById(userId),
                 feedRepository.countAllByUserId(userId),
                 followService.followedCount(userId),
-                followService.followingCount(loginId),
+                followService.followingCount(userId),
                 followService.isFollowing(loginId, userId)
         );
     }


### PR DESCRIPTION
- [x] mediaUrl을 조회하는 서브쿼리에서 2개 이상 row가 반환되는 오류 수정
- 기존에 dto직접조회 + 서브쿼리 방식으로 구현해서 문제가 생겼다.
- mediaUrl이 2개 이상이면 서브쿼리에 2개 이상의 row가 조회되어서 2개 이상의 미디어가 존재하면 게시물 목록에 나오지 않는 오류 발생
- Feed를 조회하고, 객체 그래프를 통해 조회하는 방식으로 수정
- [x] 프로필 팔로잉 목록 오류 수정
- 팔로잉한 사람 수를 대상 userId 기준으로 정정
- [x] follower 변수 순서 수정
- [x] secretStatus 변수 isSecret으로 통일
- 알고보니 json에서 자바의 getter 기준으로 식별자를 만들어주기 때문에 프론트에는 {"secret" : true} 와 같이 응답이 내려간다.
- 따로 설정을 해주지 않으면 카멜케이스 기준으로 변경된다.

close #91 