### PR TITLE
:bug: 피드 댓글에 닉네임 표시가 잘못되는 오류 수정

### DIFF
--- a/src/main/java/ogjg/instagram/feed/service/FeedService.java
+++ b/src/main/java/ogjg/instagram/feed/service/FeedService.java
@@ -163,10 +163,11 @@ public class FeedService {
     //todo : 로직을 한번에 처리하는 방법?
     private FeedDetailResponseDto.CommentThumbnailDto toCommentThumbnailResponseDto(Comment comment, Long userId) {
         Long commentId = comment.getId();
+        Long commentUserId = comment.getUser().getId();
 
         return new FeedDetailResponseDto.CommentThumbnailDto(
                 comment,
-                userService.findById(userId),
+                userService.findById(commentUserId),
                 commentLikeService.commentLikeCount(commentId),
                 commentLikeService.isCommentLiked(commentId, userId),
                 innerCommentLikeService.countInnerComment(commentId));


### PR DESCRIPTION
- [x] comment 작성자의 id로 닉네임을 반환하도록 수정
- 실수로 피드 작성자의 id가 댓글 작성자로 표시되도록 구현했다.
- comment에서 추출한 userId에 기반해 작성자를 표시하도록 변경했다.

close #94