### PR TITLE
:hammer: 로그아웃 시 브라우저 내부에 존재하는 Refresh Token 삭제

### DIFF
--- a/src/main/java/ogjg/instagram/user/controller/UserController.java
+++ b/src/main/java/ogjg/instagram/user/controller/UserController.java
@@ -48,8 +48,11 @@ public class UserController {
     }
 
     @GetMapping("/logout")
-    public ResponseEntity<?> logout(@AuthenticationPrincipal JwtUserDetails userDetails) {
-        userService.logout(userDetails.getUsername());
+    public ResponseEntity<?> logout(
+            @AuthenticationPrincipal JwtUserDetails userDetails,
+            HttpServletResponse response
+    ) {
+        userService.logout(userDetails.getUsername(), response);
         return new ResponseEntity<>("로그아웃 되었습니다.", HttpStatus.OK);
     }
 }

--- a/src/main/java/ogjg/instagram/user/service/UserService.java
+++ b/src/main/java/ogjg/instagram/user/service/UserService.java
@@ -15,6 +15,7 @@ import ogjg.instagram.user.dto.SignupRequestDto;
 import ogjg.instagram.user.repository.UserAuthenticationRepository;
 import ogjg.instagram.user.repository.UserRepository;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -122,8 +123,24 @@ public class UserService {
     }
 
     @Transactional
-    public void logout(String username) {
+    public void logout(String username, HttpServletResponse response) {
+        deleteRefreshToken(username);
+        deleteRefreshTokenCookie(response);
+    }
+
+    private void deleteRefreshToken(String username) {
         Optional<UserAuthentication> userAuth = authenticationRepository.findByUsername(username);
         userAuth.ifPresent(authenticationRepository::delete);
+    }
+
+    private void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", null)
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .build();
+        response.setHeader("Set-Cookie", cookie.toString());
     }
 }


### PR DESCRIPTION
## 로그아웃 추가 로직
- 보안적으로 브라우저 내부에 남아있는 Refresh Token을 제거가 필요하여 추가
- 같은 이름의 쿠키의 값을 null로 변경하고, 유효 시간을 0으로 지정하여 삭제되도록 구현

close #100 