### PR TITLE
:sparkles: 해시태그 검색 결과 페이지 기능 구현

### DIFF
--- a/src/main/java/ogjg/instagram/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/ogjg/instagram/hashtag/repository/HashtagRepository.java
@@ -7,5 +7,4 @@ import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     Optional<Hashtag> findByContent(String hashtag);
-
 }

--- a/src/main/java/ogjg/instagram/search/controller/SearchController.java
+++ b/src/main/java/ogjg/instagram/search/controller/SearchController.java
@@ -3,7 +3,9 @@ package ogjg.instagram.search.controller;
 import lombok.RequiredArgsConstructor;
 import ogjg.instagram.config.security.jwt.JwtUserDetails;
 import ogjg.instagram.search.service.SearchService;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -42,14 +44,19 @@ public class SearchController {
 
     /**
      * 태그 정보 및 태그 걸린 피드 가져오기
-     * todo: 구현 보류
      */
     @GetMapping("{hashtag}/feed")
-    public ResponseEntity<?> searchHashTag(@PathVariable("hashtag") String hashtag,
+    public ResponseEntity<?> searchHashTag(@PathVariable("hashtag") String content,
             @AuthenticationPrincipal JwtUserDetails userDetails
     ) {
         Long loginId = userDetails.getUserId();
-        return ResponseEntity.ok().build();
+
+        Sort sortByCreatedTime = Sort.by(Sort.Order.desc("createdAt"));
+        PageRequest pageRequest = PageRequest.of(0, 9, sortByCreatedTime);
+
+        return ResponseEntity.ok(
+                searchService.searchResult(content, pageRequest)
+        );
     }
 
 }

--- a/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResponseDto.java
+++ b/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResponseDto.java
@@ -2,10 +2,12 @@ package ogjg.instagram.search.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import ogjg.instagram.hashtag.domain.HashtagFeed;
 
 import java.util.List;
 
+@NoArgsConstructor
 @Getter
 public class SearchHashtagResponseDto {
     private boolean isUser;

--- a/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResultResponseDto.java
+++ b/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResultResponseDto.java
@@ -1,0 +1,58 @@
+package ogjg.instagram.search.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ogjg.instagram.feed.domain.Feed;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class SearchHashtagResultResponseDto {
+    private String tagName;
+    private Long feedCount;
+    private String thumbnail;
+    private List<SearchHashtagResultDto> taggedList;
+
+    public static SearchHashtagResultResponseDto from(List<Feed> feeds, Long feedCount, String content, String thumbnail) {
+        return SearchHashtagResultResponseDto.builder()
+                .taggedList(feeds.stream()
+                        .map((SearchHashtagResultDto::from))
+                        .toList())
+                .tagName(content)
+                .feedCount(feedCount)
+                .thumbnail(thumbnail)
+                .build();
+    }
+
+    @Builder
+    public SearchHashtagResultResponseDto(String tagName, Long feedCount, String thumbnail, List<SearchHashtagResultDto> taggedList) {
+        this.tagName = tagName;
+        this.feedCount = feedCount;
+        this.thumbnail = thumbnail;
+        this.taggedList = taggedList;
+    }
+
+    @Getter
+    private static class SearchHashtagResultDto {
+        private Long feedId;
+        private String mediaUrl;
+        private boolean isMediaOne;
+
+        @Builder
+        public SearchHashtagResultDto(Long feedId, String mediaUrl, boolean isMediaOne) {
+            this.feedId = feedId;
+            this.mediaUrl = mediaUrl;
+            this.isMediaOne = isMediaOne;
+        }
+
+        public static SearchHashtagResultDto from(Feed feed) {
+            return SearchHashtagResultDto.builder()
+                    .feedId(feed.getId())
+                    .mediaUrl(feed.getFeedMedias().get(0).getMediaUrl())
+                    .isMediaOne(feed.getFeedMedias().size() == 1)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/ogjg/instagram/search/repository/SearchRepository.java
+++ b/src/main/java/ogjg/instagram/search/repository/SearchRepository.java
@@ -1,0 +1,28 @@
+package ogjg.instagram.search.repository;
+
+import ogjg.instagram.feed.domain.Feed;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SearchRepository extends JpaRepository<Feed,Long> {
+
+    @Query("""
+    select f from Feed f
+        join HashtagFeed hf on f.id = hf.feed.id 
+        join Hashtag h on hf.hashtag.id = h.id
+        where h.content = :content
+""")
+    List<Feed> findFeedByContent(@Param("content") String content, Pageable pageable);
+
+    @Query("""
+    select count(f) from Feed f
+        join HashtagFeed hf on f.id = hf.feed.id 
+        join Hashtag h on hf.hashtag.id = h.id
+        where h.content = :content
+""")
+    Long countFeedByContent(@Param("content") String content);
+}

--- a/src/main/java/ogjg/instagram/search/service/SearchService.java
+++ b/src/main/java/ogjg/instagram/search/service/SearchService.java
@@ -1,16 +1,20 @@
 package ogjg.instagram.search.service;
 
 import lombok.RequiredArgsConstructor;
+import ogjg.instagram.feed.domain.Feed;
 import ogjg.instagram.follow.service.FollowService;
 import ogjg.instagram.hashtag.domain.HashtagFeed;
 import ogjg.instagram.hashtag.service.HashtagFeedService;
 import ogjg.instagram.search.dto.response.SearchHashtagResponseDto;
+import ogjg.instagram.search.dto.response.SearchHashtagResultResponseDto;
 import ogjg.instagram.search.dto.response.SearchNicknameResponseDto;
+import ogjg.instagram.search.repository.SearchRepository;
 import ogjg.instagram.user.repository.UserRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -20,6 +24,7 @@ public class SearchService {
     private final UserRepository userRepository;
     private final HashtagFeedService hashtagFeedService;
     private final FollowService followService;
+    private final SearchRepository searchRepository;
 
     //todo : slice 알아보기
     @Transactional(readOnly = true)
@@ -55,5 +60,28 @@ public class SearchService {
 
     private String wildCard(String search) {
         return "%" + search.trim() + "%";
+    }
+
+
+    /**
+     * 애초에 해당 해시태그가 한번도 사용되지 않았다면, 검색에 등장하지 않는다.
+     * 만약의 경우 태그가 1개 남아있다가 사라질때의 동시성 처리에 대비해서 count값을 확인하도록 했다.
+     */
+    @Transactional(readOnly = true)
+    public SearchHashtagResultResponseDto searchResult(String content, Pageable pageable) {
+        Long feedCount = searchRepository.countFeedByContent(content);
+        if (feedCount == 0) {
+            throw new IllegalArgumentException("해당 해시태그를 사용한 게시물이 존재하지 않습니다. hashtag=" + content);
+        }
+
+        List<Feed> feedByContent = searchRepository.findFeedByContent(content, pageable);
+        String mediaUrl = feedByContent.get(0).getFeedMedias().get(0).getMediaUrl();
+
+        return SearchHashtagResultResponseDto.from(
+                feedByContent,
+                feedCount,
+                content,
+                mediaUrl
+        );
     }
 }


### PR DESCRIPTION
- [x] dto 생성
- SearchHashtagResultResponseDto 생성
- 내부에 SearchHashtagResultDto 생성
- [x] 첫 9개 게시물만 보이도록 설정
- PageRequest를 생성해서 첫 9개 게시물만 나오도록 설정
- 정렬기준 최신 생성된 것이 우선하도록 임시 지정
- [x] 해시태그 검색 시 피드가 존재하지 않으면 예외처리
- 태그가 1개 남아있다가 사라질때의 동시성 처리에 대비해서 해시태그가 달린 게시물의 count값이 0이라면 예외를 던지도록 처리했다.

close #106