### PR TITLE
:bug: 잘못 구현한 follow 조회로직 삭제 후 기존 메서드 재활용

### DIFF
--- a/src/main/java/ogjg/instagram/follow/repository/FollowRepository.java
+++ b/src/main/java/ogjg/instagram/follow/repository/FollowRepository.java
@@ -41,12 +41,4 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     and f.followPK.followId = :followId 
     """)
     FollowResponse followerMeToo(@Param("userId") Long userId, @Param("followId") Long followId);
-
-    @Query("""
-    select new ogjg.instagram.follow.response.FollowResponse(f.followPK.userId, f.followPK.followId) 
-    from Follow f 
-    where f.followPK.userId = :userId 
-    and f.followPK.followId = :loginId 
-    """)
-    FollowResponse isFollowingUser(@Param("loginId") Long loginId, @Param("userId") Long userId);
 }

--- a/src/main/java/ogjg/instagram/follow/service/FollowService.java
+++ b/src/main/java/ogjg/instagram/follow/service/FollowService.java
@@ -85,7 +85,7 @@ public class FollowService {
 
     @Transactional(readOnly = true)
     public boolean isFollowingUser(Long loginId, Long userId) {
-        return followRepository.isFollowingUser(loginId, userId) != null;
+        return followRepository.followerMeToo(loginId, userId) != null;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/ogjg/instagram/profile/service/ProfileService.java
+++ b/src/main/java/ogjg/instagram/profile/service/ProfileService.java
@@ -31,7 +31,6 @@ public class ProfileService {
         return collectionFeedRepository.findByKeys(feedId, userId).isPresent();
     }
 
-    ///todo : Map 조회 단순화
     @Transactional(readOnly = true)
     public ProfileResponseDto findProfile(String nickname, Long loginId) {
         User user = profileRepository.findByNickname(nickname)


### PR DESCRIPTION
- [x] isFollowing 메서드 삭제
- userId가 followId를 팔로우한다. 이것을 반대로 이해하고 구현해서 오류가 생겼다.
- 해당 부분 삭제하고, 잘못 사용된 부분의 메서드를 기존의 메서드로 삭제

close #117