### PR TITLE
:sparkles: 태그 검색 결과 페이지 응답 좋아요, 댓글 개수 추가

### DIFF
--- a/src/main/java/ogjg/instagram/search/dto/SearchHashTagCountDto.java
+++ b/src/main/java/ogjg/instagram/search/dto/SearchHashTagCountDto.java
@@ -1,0 +1,16 @@
+package ogjg.instagram.search.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SearchHashTagCountDto {
+    private Long feedId;
+    private Long likeCount;
+    private Long commentCount;
+
+    public SearchHashTagCountDto(Long feedId, Long likeCount, Long commentCount) {
+        this.feedId = feedId;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+    }
+}

--- a/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResultResponseDto.java
+++ b/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResultResponseDto.java
@@ -15,11 +15,9 @@ public class SearchHashtagResultResponseDto {
     private String thumbnail;
     private List<SearchHashtagResultDto> taggedList;
 
-    public static SearchHashtagResultResponseDto from(List<Feed> feeds, Long feedCount, String content, String thumbnail) {
+    public static SearchHashtagResultResponseDto from(List<SearchHashtagResultDto> feeds, Long feedCount, String content, String thumbnail) {
         return SearchHashtagResultResponseDto.builder()
-                .taggedList(feeds.stream()
-                        .map((SearchHashtagResultDto::from))
-                        .toList())
+                .taggedList(feeds)
                 .tagName(content)
                 .feedCount(feedCount)
                 .thumbnail(thumbnail)
@@ -35,7 +33,7 @@ public class SearchHashtagResultResponseDto {
     }
 
     @Getter
-    private static class SearchHashtagResultDto {
+    public static class SearchHashtagResultDto {
         private Long feedId;
         private String mediaUrl;
         private boolean isMediaOne;

--- a/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResultResponseDto.java
+++ b/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResultResponseDto.java
@@ -39,12 +39,16 @@ public class SearchHashtagResultResponseDto {
         private Long feedId;
         private String mediaUrl;
         private boolean isMediaOne;
+        private Long likeCount;
+        private Long commentCount;
 
         @Builder
-        public SearchHashtagResultDto(Long feedId, String mediaUrl, boolean isMediaOne) {
+        public SearchHashtagResultDto(Long feedId, String mediaUrl, boolean isMediaOne, Long likeCount, Long commentCount) {
             this.feedId = feedId;
             this.mediaUrl = mediaUrl;
             this.isMediaOne = isMediaOne;
+            this.likeCount = likeCount;
+            this.commentCount = commentCount;
         }
 
         public static SearchHashtagResultDto from(Feed feed) {
@@ -52,6 +56,8 @@ public class SearchHashtagResultResponseDto {
                     .feedId(feed.getId())
                     .mediaUrl(feed.getFeedMedias().get(0).getMediaUrl())
                     .isMediaOne(feed.getFeedMedias().size() == 1)
+                    .likeCount(Long.valueOf(feed.getFeedLikes().size()))
+                    .commentCount(Long.valueOf(feed.getComments().size()))
                     .build();
         }
     }

--- a/src/main/java/ogjg/instagram/search/repository/SearchRepository.java
+++ b/src/main/java/ogjg/instagram/search/repository/SearchRepository.java
@@ -1,6 +1,7 @@
 package ogjg.instagram.search.repository;
 
 import ogjg.instagram.feed.domain.Feed;
+import ogjg.instagram.search.dto.SearchHashTagCountDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,7 +16,7 @@ public interface SearchRepository extends JpaRepository<Feed,Long> {
         join HashtagFeed hf on f.id = hf.feed.id 
         join Hashtag h on hf.hashtag.id = h.id
         where h.content = :content
-""")
+    """)
     List<Feed> findFeedByContent(@Param("content") String content, Pageable pageable);
 
     @Query("""
@@ -23,6 +24,16 @@ public interface SearchRepository extends JpaRepository<Feed,Long> {
         join HashtagFeed hf on f.id = hf.feed.id 
         join Hashtag h on hf.hashtag.id = h.id
         where h.content = :content
-""")
+    """)
     Long countFeedByContent(@Param("content") String content);
+
+    @Query("""
+    SELECT new ogjg.instagram.search.dto.SearchHashTagCountDto(f.id ,COUNT(fl.feed.id), COUNT(c.id))
+    FROM Feed f
+    LEFT JOIN  f.feedLikes fl
+    LEFT JOIN  f.comments c
+    WHERE  f IN :feeds
+    GROUP BY f.id
+    """)
+    List<SearchHashTagCountDto> findFeedLikeCountAndCommentCount(@Param("feeds") List<Feed> feeds);
 }

--- a/src/main/java/ogjg/instagram/search/service/SearchService.java
+++ b/src/main/java/ogjg/instagram/search/service/SearchService.java
@@ -8,6 +8,7 @@ import ogjg.instagram.follow.service.FollowService;
 import ogjg.instagram.hashtag.domain.HashtagFeed;
 import ogjg.instagram.hashtag.service.HashtagFeedService;
 import ogjg.instagram.like.repository.FeedLikeRepository;
+import ogjg.instagram.search.dto.SearchHashTagCountDto;
 import ogjg.instagram.search.dto.response.SearchHashtagResponseDto;
 import ogjg.instagram.search.dto.response.SearchHashtagResultResponseDto;
 import ogjg.instagram.search.dto.response.SearchNicknameResponseDto;
@@ -18,7 +19,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +43,7 @@ public class SearchService {
                 hashtagFeedService.findByHashtagContaining(wildCard(searchKey), pageable)
                         .getContent().stream()
                         .map(this::toSearchHashtagDto)
-                        .collect(Collectors.toUnmodifiableList()),
+                        .collect(toUnmodifiableList()),
                 isUser
         );
 
@@ -60,7 +64,7 @@ public class SearchService {
                         .map((user) -> SearchNicknameResponseDto.SearchNicknameDto.of(
                                 user,
                                 followService.isFollowingUser(loginId, user.getId())))
-                        .collect(Collectors.toUnmodifiableList()),
+                        .collect(toUnmodifiableList()),
                 isUser);
     }
 
@@ -79,12 +83,19 @@ public class SearchService {
             throw new IllegalArgumentException("해당 해시태그를 사용한 게시물이 존재하지 않습니다. hashtag=" + content);
         }
 
-        List<Feed> feedByContent = searchRepository.findFeedByContent(content, pageable);
-        String thumbnail = feedByContent.get(0).getFeedMedias().get(0).getMediaUrl();
+        List<Feed> findFeed = searchRepository.findFeedByContent(content, pageable);
+        Map<Long, SearchHashTagCountDto> countMap = searchRepository.findFeedLikeCountAndCommentCount(findFeed)
+                .stream()
+                .collect(toMap(
+                        (dto) -> dto.getFeedId(),
+                        (dto) -> dto)
+                );
+
+        String thumbnail = findFeed.get(0).getFeedMedias().get(0).getMediaUrl();
 
         return SearchHashtagResultResponseDto.from(
-                feedByContent.stream()
-                        .map(this::toSearchHashtagResultDto)
+                findFeed.stream()
+                        .map((feed -> toSearchHashtagResultDto(feed, countMap.get(feed.getId()))))
                         .toList(),
                 feedCount,
                 content,
@@ -92,14 +103,13 @@ public class SearchService {
         );
     }
 
-    // todo : 여기서 count들을 group으로 한 번에 받아오기
-    private SearchHashtagResultResponseDto.SearchHashtagResultDto toSearchHashtagResultDto(Feed feed) {
+    private SearchHashtagResultResponseDto.SearchHashtagResultDto toSearchHashtagResultDto(Feed feed, SearchHashTagCountDto countDto) {
         return SearchHashtagResultResponseDto.SearchHashtagResultDto.builder()
                 .feedId(feed.getId())
                 .mediaUrl(feed.getFeedMedias().get(0).getMediaUrl())
                 .isMediaOne(feed.getFeedMedias().size() == 1)
-                .likeCount(feedLikeRepository.countLikes(feed.getId()))
-                .commentCount(commentRepository.countByFeedId(feed.getId()))
+                .likeCount(countDto.getLikeCount())
+                .commentCount(countDto.getCommentCount())
                 .build();
     }
 }

--- a/src/main/java/ogjg/instagram/search/service/SearchService.java
+++ b/src/main/java/ogjg/instagram/search/service/SearchService.java
@@ -1,10 +1,13 @@
 package ogjg.instagram.search.service;
 
 import lombok.RequiredArgsConstructor;
+import ogjg.instagram.comment.repository.CommentRepository;
 import ogjg.instagram.feed.domain.Feed;
+import ogjg.instagram.feed.repository.FeedMediaRepository;
 import ogjg.instagram.follow.service.FollowService;
 import ogjg.instagram.hashtag.domain.HashtagFeed;
 import ogjg.instagram.hashtag.service.HashtagFeedService;
+import ogjg.instagram.like.repository.FeedLikeRepository;
 import ogjg.instagram.search.dto.response.SearchHashtagResponseDto;
 import ogjg.instagram.search.dto.response.SearchHashtagResultResponseDto;
 import ogjg.instagram.search.dto.response.SearchNicknameResponseDto;
@@ -25,6 +28,9 @@ public class SearchService {
     private final HashtagFeedService hashtagFeedService;
     private final FollowService followService;
     private final SearchRepository searchRepository;
+    private final FeedLikeRepository feedLikeRepository;
+    private final CommentRepository commentRepository;
+    private final FeedMediaRepository feedMediaRepository;
 
     //todo : slice 알아보기
     @Transactional(readOnly = true)
@@ -62,7 +68,6 @@ public class SearchService {
         return "%" + search.trim() + "%";
     }
 
-
     /**
      * 애초에 해당 해시태그가 한번도 사용되지 않았다면, 검색에 등장하지 않는다.
      * 만약의 경우 태그가 1개 남아있다가 사라질때의 동시성 처리에 대비해서 count값을 확인하도록 했다.
@@ -75,13 +80,26 @@ public class SearchService {
         }
 
         List<Feed> feedByContent = searchRepository.findFeedByContent(content, pageable);
-        String mediaUrl = feedByContent.get(0).getFeedMedias().get(0).getMediaUrl();
+        String thumbnail = feedByContent.get(0).getFeedMedias().get(0).getMediaUrl();
 
         return SearchHashtagResultResponseDto.from(
-                feedByContent,
+                feedByContent.stream()
+                        .map(this::toSearchHashtagResultDto)
+                        .toList(),
                 feedCount,
                 content,
-                mediaUrl
+                thumbnail
         );
+    }
+
+    // todo : 여기서 count들을 group으로 한 번에 받아오기
+    private SearchHashtagResultResponseDto.SearchHashtagResultDto toSearchHashtagResultDto(Feed feed) {
+        return SearchHashtagResultResponseDto.SearchHashtagResultDto.builder()
+                .feedId(feed.getId())
+                .mediaUrl(feed.getFeedMedias().get(0).getMediaUrl())
+                .isMediaOne(feed.getFeedMedias().size() == 1)
+                .likeCount(feedLikeRepository.countLikes(feed.getId()))
+                .commentCount(commentRepository.countByFeedId(feed.getId()))
+                .build();
     }
 }


### PR DESCRIPTION
- [x] 태그 검색 결과 페이지에서 각 피드 목록에 대하여 댓글 개수 및 좋아요 개수 추가
- likeCount, commentCount 추가
- 객체 그래프 조회 방식으로 구현
- [x] dto 직접 조회 방식 활용. count 정보들을 한 번에 조회하도록 수정
-  피드들의 likeCount와 commentCount를 한 번에 조회하도록 변경
- List로 conut 내용들을 받아오고, Map으로 변환해서 dto 초기화 파라미터에 전달
- likeCount, commentCount에 대해  쿼리문이 각각 (결과 화면 조회되는) 최대 게시물 개수인 9개씩 총 18개가 발생 ->  1개로 최적화
- 해당 service api의 총 쿼리 수 4개로 단축

close #122 