### PR TITLE
:rocket: health check 경로에 대한 요청 권한 삭제

### DIFF
--- a/src/main/java/ogjg/instagram/config/security/SecurityConfig.java
+++ b/src/main/java/ogjg/instagram/config/security/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                     "/api/users/email/.*",
                     "/api/users/nickname/.*",
                     "/api/users/exist",
-                    "/api/users/auth"
+                    "/api/users/auth",
+                    "/health"
             ));
 
     @Bean


### PR DESCRIPTION
### 문제 상황 및 해결
```
Health checks failed with these codes: [401]
```
- ELB에서 상태점검을 위해 요청보내는 요청이 애플리케이션 상의 Security Filter에 막혀 `401` 상태 코드를 반환합니다.
- 허용 URL 리스트에 `/health` 경로를 추가하여 해결

close #124