### PR TITLE
:sparkles: 팔로워목록 팔로워 삭제하기

### DIFF
--- a/src/main/java/ogjg/instagram/follow/controller/FollowController.java
+++ b/src/main/java/ogjg/instagram/follow/controller/FollowController.java
@@ -38,6 +38,15 @@ public class FollowController {
         return ResponseEntity.ok().build();
     }
 
+    @DeleteMapping("/{followId}/follower")
+    public ResponseEntity<Void> followerListDelete(
+            @PathVariable Long followId,
+            @AuthenticationPrincipal JwtUserDetails userDetails
+    ){
+        followService.unfollow(followId,userDetails.getUserId());
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/following/{userId}")
     public ResponseEntity<List<FollowResponse>> following(
             @PathVariable("userId") Long userId

--- a/src/main/java/ogjg/instagram/follow/controller/FollowController.java
+++ b/src/main/java/ogjg/instagram/follow/controller/FollowController.java
@@ -43,7 +43,7 @@ public class FollowController {
             @PathVariable Long followId,
             @AuthenticationPrincipal JwtUserDetails userDetails
     ){
-        followService.unfollow(followId,userDetails.getUserId());
+        followService.unfollow(followId, userDetails.getUserId());
         return ResponseEntity.ok().build();
     }
 


### PR DESCRIPTION
### 팔로워 목록 에서 팔로워 삭제하기

- [x] 팔로워 목록에서 사용자가 팔로워 삭제하기 기능 추가

```
@DeleteMapping("/{followId}/follower")
    public ResponseEntity<Void> followerListDelete(
            @PathVariable Long followId,
            @AuthenticationPrincipal JwtUserDetails userDetails
    ){
        followService.unfollow(followId,userDetails.getUserId());
        return ResponseEntity.ok().build();
    }
```
팔로워 목록내에서 계정의 주인이 자신이 팔로우한 사용자를 삭제 하는 기능
unfollow의 기능에서 userId와 followId의 순서만 변경

close #126 