### PR TITLE
hashtag검색 시에 중복된 검색 목록이 나오는 오류 수정

### DIFF
--- a/src/main/java/ogjg/instagram/feed/service/FeedService.java
+++ b/src/main/java/ogjg/instagram/feed/service/FeedService.java
@@ -147,7 +147,6 @@ public class FeedService {
                 .build();
     }
 
-    //todo : Map 조회 단순화
     @Transactional(readOnly = true)
     public FeedDetailResponseDto findDetail(Long feedId, Long userId) {
         Feed feed = findDetailById(feedId);

--- a/src/main/java/ogjg/instagram/hashtag/domain/HashtagFeed.java
+++ b/src/main/java/ogjg/instagram/hashtag/domain/HashtagFeed.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ogjg.instagram.feed.domain.Feed;
 
+import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -21,7 +22,7 @@ public class HashtagFeed {
     private HashtagPK hashtagPK;
 
     @MapsId("hashtagId")
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY, cascade = REMOVE)
     private Hashtag hashtag;
 
     @MapsId("feedId")

--- a/src/main/java/ogjg/instagram/hashtag/repository/HashtagFeedRepository.java
+++ b/src/main/java/ogjg/instagram/hashtag/repository/HashtagFeedRepository.java
@@ -1,19 +1,8 @@
 package ogjg.instagram.hashtag.repository;
 
 import ogjg.instagram.hashtag.domain.HashtagFeed;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface HashtagFeedRepository extends JpaRepository<HashtagFeed, Long> {
-    @Query("""
-            SELECT hf FROM HashtagFeed hf
-            join fetch hf.feed f
-            join fetch hf.hashtag h WHERE h.content LIKE :searchKey
-            """)
-    Page<HashtagFeed> findByHashtagContaining(@Param("searchKey") String searchKey, Pageable pageable);
-
     Long countByHashtagId(Long hashtagId);
 }

--- a/src/main/java/ogjg/instagram/hashtag/repository/HashtagRepository.java
+++ b/src/main/java/ogjg/instagram/hashtag/repository/HashtagRepository.java
@@ -1,10 +1,20 @@
 package ogjg.instagram.hashtag.repository;
 
 import ogjg.instagram.hashtag.domain.Hashtag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     Optional<Hashtag> findByContent(String hashtag);
+
+    @Query("""
+            SELECT h FROM Hashtag h
+            WHERE h.content LIKE :searchKey
+            """)
+    Page<Hashtag> findByHashtagContaining(@Param("searchKey") String searchKey, Pageable pageable);
 }

--- a/src/main/java/ogjg/instagram/hashtag/service/HashtagFeedService.java
+++ b/src/main/java/ogjg/instagram/hashtag/service/HashtagFeedService.java
@@ -6,8 +6,6 @@ import ogjg.instagram.hashtag.domain.Hashtag;
 import ogjg.instagram.hashtag.domain.HashtagFeed;
 import ogjg.instagram.hashtag.domain.HashtagPK;
 import ogjg.instagram.hashtag.repository.HashtagFeedRepository;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,11 +33,5 @@ public class HashtagFeedService {
     public Long countTaggedFeeds(Long hashtagId) {
         return hashtagFeedRepository.countByHashtagId(hashtagId);
     }
-
-    @Transactional(readOnly = true)
-    public Page<HashtagFeed> findByHashtagContaining(String wildCard, Pageable pageable) {
-        return hashtagFeedRepository.findByHashtagContaining(wildCard, pageable);
-    }
-
 
 }

--- a/src/main/java/ogjg/instagram/hashtag/service/HashtagService.java
+++ b/src/main/java/ogjg/instagram/hashtag/service/HashtagService.java
@@ -3,6 +3,8 @@ package ogjg.instagram.hashtag.service;
 import lombok.RequiredArgsConstructor;
 import ogjg.instagram.hashtag.domain.Hashtag;
 import ogjg.instagram.hashtag.repository.HashtagRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,14 +16,14 @@ public class HashtagService {
 
     private final HashtagRepository hashtagRepository;
 
-//    @Transactional(readOnly = true)
-//    public Hashtag findByHashtag(String hashtag) {
-//        return hashtagRepository.findByContent(hashtag)
-//                .orElseThrow(() -> new IllegalArgumentException("해당 해시태그가 존재하지 않습니다. hashtag=" + hashtag));
-//    }
-
     @Transactional
     public List<Hashtag> saveAll(List<Hashtag> hashtags) {
         return hashtagRepository.saveAll(hashtags);
+    }
+
+
+    @Transactional(readOnly = true)
+    public Page<Hashtag> findByHashtagContaining(String wildCard, Pageable pageable) {
+        return hashtagRepository.findByHashtagContaining(wildCard, pageable);
     }
 }

--- a/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResponseDto.java
+++ b/src/main/java/ogjg/instagram/search/dto/response/SearchHashtagResponseDto.java
@@ -3,7 +3,7 @@ package ogjg.instagram.search.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ogjg.instagram.hashtag.domain.HashtagFeed;
+import ogjg.instagram.hashtag.domain.Hashtag;
 
 import java.util.List;
 
@@ -39,9 +39,9 @@ public class SearchHashtagResponseDto {
             this.totalFeedCount = totalFeedCount;
         }
 
-        public static SearchHashtagDto of(HashtagFeed hashtagFeed, Long totalFeedCount) {
+        public static SearchHashtagDto of(Hashtag hashtag, Long totalFeedCount) {
             return SearchHashtagDto.builder()
-                    .tagName(hashtagFeed.getHashtag().getContent())
+                    .tagName(hashtag.getContent())
                     .totalFeedCount(totalFeedCount)
                     .build();
         }

--- a/src/main/java/ogjg/instagram/search/service/SearchService.java
+++ b/src/main/java/ogjg/instagram/search/service/SearchService.java
@@ -1,13 +1,11 @@
 package ogjg.instagram.search.service;
 
 import lombok.RequiredArgsConstructor;
-import ogjg.instagram.comment.repository.CommentRepository;
 import ogjg.instagram.feed.domain.Feed;
-import ogjg.instagram.feed.repository.FeedMediaRepository;
 import ogjg.instagram.follow.service.FollowService;
-import ogjg.instagram.hashtag.domain.HashtagFeed;
+import ogjg.instagram.hashtag.domain.Hashtag;
 import ogjg.instagram.hashtag.service.HashtagFeedService;
-import ogjg.instagram.like.repository.FeedLikeRepository;
+import ogjg.instagram.hashtag.service.HashtagService;
 import ogjg.instagram.search.dto.SearchHashTagCountDto;
 import ogjg.instagram.search.dto.response.SearchHashtagResponseDto;
 import ogjg.instagram.search.dto.response.SearchHashtagResultResponseDto;
@@ -30,17 +28,15 @@ public class SearchService {
 
     private final UserRepository userRepository;
     private final HashtagFeedService hashtagFeedService;
+    private final HashtagService hashtagService;
     private final FollowService followService;
     private final SearchRepository searchRepository;
-    private final FeedLikeRepository feedLikeRepository;
-    private final CommentRepository commentRepository;
-    private final FeedMediaRepository feedMediaRepository;
 
     //todo : slice 알아보기
     @Transactional(readOnly = true)
     public SearchHashtagResponseDto searchByHashtag(boolean isUser, String searchKey, Pageable pageable) {
         return SearchHashtagResponseDto.from(
-                hashtagFeedService.findByHashtagContaining(wildCard(searchKey), pageable)
+                hashtagService.findByHashtagContaining(wildCard(searchKey), pageable)
                         .getContent().stream()
                         .map(this::toSearchHashtagDto)
                         .collect(toUnmodifiableList()),
@@ -49,10 +45,10 @@ public class SearchService {
 
     }
 
-    private SearchHashtagResponseDto.SearchHashtagDto toSearchHashtagDto(HashtagFeed hashtagFeed) {
+    private SearchHashtagResponseDto.SearchHashtagDto toSearchHashtagDto(Hashtag hashtag) {
         return  SearchHashtagResponseDto.SearchHashtagDto.of(
-                hashtagFeed,
-                hashtagFeedService.countTaggedFeeds(hashtagFeed.getHashtag().getId())
+                hashtag,
+                hashtagFeedService.countTaggedFeeds(hashtag.getId())
         );
     }
 


### PR DESCRIPTION
- [x]  Feed 삭제시 오류 수정
- Feed 삭제시 Hashtag 테이블의 데이터가 지워지지 않는 문제 발생
- HashtagFeed에 cascade = REMOVE 옵션 추가
- [x]  hashtag 검색 결과 오류 수정
- HashtagFeedRepository에서 fetch join을 잘못써서 중복된 데이터가 검색되는 문제 발생
- HashtagRepository에서 content(해시태그 문자열)로 검색하도록 수정
    

close #128 
