### PR TITLE
:bug: 리프레시 토큰 버그 수정

### DIFF
--- a/src/main/java/ogjg/instagram/user/repository/UserAuthenticationRepository.java
+++ b/src/main/java/ogjg/instagram/user/repository/UserAuthenticationRepository.java
@@ -9,4 +9,6 @@ public interface UserAuthenticationRepository extends JpaRepository<UserAuthenti
     Optional<UserAuthentication> findByUsername(String username);
 
     Optional<UserAuthentication> findByNickname(String nickname);
+
+    Optional<UserAuthentication> findByRefreshToken(String refreshToken);
 }


### PR DESCRIPTION
### 문제 상황
- 리프레시 토큰이 유효하지 않아도 상태코드를 200으로 응답
- 엑세스 토큰이 발급되지 않아서 프론트 코드에서 무한 재발급 요청이 발생

### 문제 코드
- 리프레시 토큰 예외 처리 중 처리하지 못한 부분이 존재

### 해결
- 유저 인증 정보에 존재하는 리프레시 토큰과 요청 리프레시 토큰이 일치하지 않는 경우 예외를 발생시키도록 처리
- 리프레시 토큰이 없는 요청에도 예외 처리
    - `Optional.ofNullable()`을 통해 요청에 쿠키가 없어도 스트림 도중 예외가 발생하지 않도록 처리

close #132 